### PR TITLE
allow a config path relative to the sublime working folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ If you've created a config file, you have to configure its path in the plugin's 
         "config": "/path/to/.phpcsfixer"
     }
 
+When using multiple projects with different configurations, it's possible to configure the path relative to the Sublime project folder:
+
+    {
+        "config": "${folder}/.php_cs.dist"
+    }
+
 Please note that this plugin don't try to find the config file automatically. If you want to create a config file, you have to specify its path in the plugin settings.
 
 Although you can configure the rules directly on your plugin settings, it's recommended to create the config file, as it's easier to configure every rule than using the 'rules' directive in the plugin settings.

--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -101,6 +101,10 @@ def format_file(tmp_file):
     cmd = [path, "fix", "--using-cache=off", tmp_file]
     
     if config:
+        variables = sublime.active_window().extract_variables()
+        if 'folder' in variables:
+            config = config.replace('${folder}', variables['folder'])
+        
         cmd.append('--config=' + config)
     
     if rules:


### PR DESCRIPTION
When working on several projects, each with their own php codestyle, this PR allows configuring the config path relative to the project's working directory, by replacing `${folder}` with the sublime working directory.

This works both when working with actual sublime projects, or when opening a directory with sublime (eg. starting sublime using `subl ~/my_project`)