### PR TITLE
fix(Path): Update path to look in COMPOSER_HOME

### DIFF
--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -51,7 +51,7 @@ def locate_in_windows():
 
 
 def locate_in_linux():
-    path = os.environ["HOME"] + "/.composer/vendor/bin/php-cs-fixer"
+    path = os.environ["COMPOSER_HOME"] + "/vendor/bin/php-cs-fixer"
     if is_file(path):
         return path
     else:


### PR DESCRIPTION
Instead of looking in the $HOME directly for the vendor/bin/php-cs-fixer, it should go to composer's home directory.