### PR TITLE
more flexible ways to find the `.php-cs` config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ When using multiple projects with different configurations, it's possible to con
         "config": "${folder}/.php_cs.dist"
     }
 
+It's also possible to specify multiple config paths. In that case, the first readable file is used:
+
+    {
+        "config": [
+            "${file_path}/.php_cs",
+            "${file_path}/.php_cs.dist",
+            "${folder}/.php_cs",
+            "${folder}/.php_cs.dist",
+            "/path/to/.phpcsfixer"
+        ]
+    }
+
+See [`extract_variables` in the Sublime API Reference](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window) for the supported replacement variables.
+
 Please note that this plugin don't try to find the config file automatically. If you want to create a config file, you have to specify its path in the plugin settings.
 
 Although you can configure the rules directly on your plugin settings, it's recommended to create the config file, as it's easier to configure every rule than using the 'rules' directive in the plugin settings.


### PR DESCRIPTION
This PR does 2 things:
 - support replacement of all variables returned by [`extract_variables`](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window)
 - makes it possible to use a list of paths to the `.php-cs` config file, where the first readable one is used, eg:
```
{
    "config": [
        "${folder}/.php_cs",
        "${folder}/.php_cs.dist",
        "${file_path}/.php_cs",
        "${file_path}/.php_cs.dist",
        "/home/johndoe/.php_cs"
    ]
}
```
