### PR TITLE
Change `folder` variable to proper one for current file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a plugin for Sublime Text 3 to format PHP code through php-cs-fixer comm
 * Fast
 * Easy
 * Configurable through rules or a config file
-* Tested on Windows and Linux 
+* Tested on Windows and Linux
 
 # Configuration
 
@@ -21,17 +21,17 @@ Also you can create a config file as explained here https://github.com/FriendsOf
 
 *for example in:* `$HOME/.phpcsfixer`
 
-    <?php     
+    <?php
     return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
     ]);
-    
+
 If you've created a config file, you have to configure its path in the plugin's settings.
 
 *In Menu -> Preferences -> Package Settings -> PHP CS Fixer -> Settings - user*
-    
+
     {
         "config": "/path/to/.phpcsfixer"
     }
@@ -54,7 +54,7 @@ It's also possible to specify multiple config paths. In that case, the first rea
         ]
     }
 
-See [`extract_variables` in the Sublime API Reference](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window) for the supported replacement variables.
+See [`extract_variables` in the Sublime API Reference](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window) for the supported replacement variables. The value of the `${folder}` points the path of the first project in Sublime API. Here, it's beforehand replaced with the path of the project the target file belongs.
 
 Please note that this plugin don't try to find the config file automatically. If you want to create a config file, you have to specify its path in the plugin settings.
 
@@ -62,9 +62,9 @@ Although you can configure the rules directly on your plugin settings, it's reco
 
 ### On Windows:
 
-The plugin tries to find the executable in: 
+The plugin tries to find the executable in:
 
-    %APPDATA%\composer\vendor\bin\php-cs-fixer.bat 
+    %APPDATA%\composer\vendor\bin\php-cs-fixer.bat
 
 If it isn't working, you can locate your composer global packages path by running:
 
@@ -75,7 +75,7 @@ If it isn't working, you can locate your composer global packages path by runnin
 After installing php-cs-fixer you have to specify the full path to the
 executable in the configuration page.
 
-The plugin tries to find the executable in: 
+The plugin tries to find the executable in:
 
     $HOME/.composer/vendor/bin/php-cs-fixer
 

--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -145,6 +145,11 @@ def format_file(tmp_file):
             configs = [configs]
 
         variables = sublime.active_window().extract_variables()
+
+        folder = get_project_folder(variables['file'])
+        if folder:
+            variables['folder'] = folder
+
         for config in configs:
             config_path = sublime.expand_variables(config, variables)
             if is_readable_file(config_path):
@@ -178,6 +183,17 @@ def create_process_for_platform(cmd):
         si = None
 
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, startupinfo=si)
+
+
+def get_project_folder(file):
+    project_folders = sublime.active_window().project_data().get('folders', [])
+    print(project_folders)
+    project_paths = (p['path'] for p in project_folders)
+    for path in project_paths:
+        if file.startswith(path):
+            return path
+
+    return None
 
 
 class SublimePhpCsFixCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
This PR is for a follow-up change for the PR #15.

https://github.com/adael/SublimePhpCsFixer/pull/15#issuecomment-331310095

The variable `folder` which can be used in the variable `config` always points the first project folder . When multiple projects are open, using that value is not preferable.

So it's better to change the variable value to the proper one for the current file.