### PR TITLE
Remove unnecessary print().

### DIFF
--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -187,7 +187,6 @@ def create_process_for_platform(cmd):
 
 def get_project_folder(file):
     project_folders = sublime.active_window().project_data().get('folders', [])
-    print(project_folders)
     project_paths = (p['path'] for p in project_folders)
     for path in project_paths:
         if file.startswith(path):


### PR DESCRIPTION
I'm sorry, I left `print()` by mistake in the last PR https://github.com/adael/SublimePhpCsFixer/pull/17 .

This is a PR with one-line change of `print()`.