### PR TITLE
Check if the command should run

### DIFF
--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -209,6 +209,9 @@ def get_project_folder(file):
 
 
 class SublimePhpCsFixCommand(sublime_plugin.TextCommand):
+    def is_enabled(self):
+        return self.is_supported_scope(self.view)
+
     def run(self, edit):
         try:
             log_to_console("Formatting view...")
@@ -226,6 +229,9 @@ class SublimePhpCsFixCommand(sublime_plugin.TextCommand):
                 log_to_console("Done. No contents")
         except ExecutableNotFoundException as e:
             log_to_console(str(e))
+
+    def is_supported_scope(self, view):
+        return 'embedding.php' in view.scope_name(self.view.sel()[0].begin())
 
 
 class SublimePhpCsFixListener(sublime_plugin.EventListener):


### PR DESCRIPTION
closes #24

It will run the command only if the current cursor position scope contains `embedding.php`, which is everywhere in a php file. :)

As far as I understand (I never heard of `.ctp` :D)  to have syntax higlighting for `.ctp` you need to set the syntax to `PHP`. And by doing so, it shouldn't matter if the file extension ends with `.ctp` as long as the scope at the cursor contains `embedding.php`, the command will fire.

If you have any suggestion, question or concern, I am here :)