### PR TITLE
Added setting to exclude paths from php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Please note that this plugin don't try to find the config file automatically. If
 
 Although you can configure the rules directly on your plugin settings, it's recommended to create the config file, as it's easier to configure every rule than using the 'rules' directive in the plugin settings.
 
+## Exclude files
+
+Since all PHP files are passed directly to the php-cs-fixer executable, a configured PhpCsFixer\\Finder gets ignored.
+In order to exclude files from php-cs-fixer, you can use the "exclude" setting:
+
+    {
+        "exclude": [
+            ".*\\.phtml$"
+        ]
+    }
+
+
 ### On Windows:
 
 The plugin tries to find the executable in:

--- a/README.md
+++ b/README.md
@@ -62,16 +62,18 @@ Although you can configure the rules directly on your plugin settings, it's reco
 
 ## Exclude files
 
-Since all PHP files are passed directly to the php-cs-fixer executable, a configured PhpCsFixer\\Finder gets ignored.
+Since all php files are passed directly to the php-cs-fixer executable, a configured PhpCsFixer\\Finder gets ignored.
 In order to exclude files from php-cs-fixer, you can use the "exclude" setting:
 
     {
         "exclude": [
-            ".*\\.phtml$"
+            ".*[\\\\/]vendor[\\\\/].*", // vendor-path (used by Composer)
+            ".*\\.phtml$" // files ending with ".phtml"
         ]
     }
 
-The exclude-filter uses python regular expressions, for more information see: https://docs.python.org/2/library/re.html
+The exclude-filter uses python regular expressions.
+For more information see: https://docs.python.org/2/library/re.html
 
 
 ### On Windows:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ In order to exclude files from php-cs-fixer, you can use the "exclude" setting:
         ]
     }
 
+The exclude-filter uses python regular expressions, for more information see: https://docs.python.org/2/library/re.html
+
 
 ### On Windows:
 

--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -236,9 +236,7 @@ class SublimePhpCsFixCommand(sublime_plugin.TextCommand):
     def is_supported_scope(self, view):
         return 'embedding.php' in view.scope_name(view.sel()[0].begin()) and not self.is_excluded(view)
 
-    def is_excluded(self, view):
-        log_to_console(self.settings)
-        
+    def is_excluded(self, view):        
         if not self.settings.has('exclude'):
             return False
 

--- a/SublimePhpCsFixer.sublime-settings
+++ b/SublimePhpCsFixer.sublime-settings
@@ -4,6 +4,6 @@
     "rules": "",
     "config": "",
     "on_save": false,
-    "on_load": false
+    "on_load": false,
     "exclude": []
 }

--- a/SublimePhpCsFixer.sublime-settings
+++ b/SublimePhpCsFixer.sublime-settings
@@ -5,4 +5,8 @@
     "config": "",
     "on_save": false,
     "on_load": false
+    "exclude": [
+      ".*[\\/](vendor|svn)[\\/].*",
+      "\\..*$",
+    ]
 }

--- a/SublimePhpCsFixer.sublime-settings
+++ b/SublimePhpCsFixer.sublime-settings
@@ -5,8 +5,5 @@
     "config": "",
     "on_save": false,
     "on_load": false
-    "exclude": [
-      ".*[\\/](vendor|svn)[\\/].*",
-      "\\..*$",
-    ]
+    "exclude": []
 }


### PR DESCRIPTION
Since php-cs-fixer ignores a configured Finder object if a path is directly passed as an argument, i added a "exclude" setting to exclude files/paths based on regular-expressions.

The "exclude" setting accepts a string or a list-of-strings which are passed directly to re.match() for each view (file-name). Some examples are available in the README.md file.