### PR TITLE
Fix formatting when no project is loaded

### DIFF
--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -52,8 +52,9 @@ def fixer_possible_paths():
         executable_name = "php-cs-fixer"
 
     project_data = sublime.active_window().project_data()
-    project_path = project_data['folders'][0]['path']
-    paths.append(os.path.join(project_path, "vendor", "bin", executable_name))
+    if project_data:
+        project_path = project_data['folders'][0]['path']
+        paths.append(os.path.join(project_path, "vendor", "bin", executable_name))
 
     if "COMPOSER_HOME" in os.environ:
         paths.append(os.path.join(


### PR DESCRIPTION
When no project is loaded (for example when editing single file by `subl --new-window somefile`), then plugin fails with stacktrace:

```
PHP CS Fixer: Formatting view...
PHP CS Fixer: Using config: /home/godric/.php-cs-fixer.php
Traceback (most recent call last):
  File "/opt/sublime_text/Lib/python33/sublime_plugin.py", line 1494, in run_
    return self.run(edit)
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 315, in run
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 329, in format
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 264, in format
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 288, in format_contents
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 300, in format_file
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 162, in run
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 184, in create_cmd
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 234, in get_configured_php_cs_fixer_path
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 246, in locate_php_cs_fixer
  File "/home/godric/.config/sublime-text-3/Installed Packages/PHP CS Fixer.sublime-package/SublimePhpCsFixer.py", line 55, in fixer_possible_paths
TypeError: 'NoneType' object is not subscriptable
```

This handles the situation and tries to load `<project>/vendor/bin/php-cs-fixer` only when project is not None.